### PR TITLE
Stripe Webhookを実装して決済完了時のみメール送信するよう修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 # Stripe
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key
 STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
+STRIPE_WEBHOOK_SECRET=whsec_your_stripe_webhook_secret
 
 # Application
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/STRIPE_WEBHOOK_SETUP.md
+++ b/STRIPE_WEBHOOK_SETUP.md
@@ -1,0 +1,161 @@
+# Stripe Webhook設定手順
+
+## 概要
+決済完了時にメールを送信するため、Stripe Webhookを設定する必要があります。
+これにより、実際に決済が成功した場合のみメールが送信されるようになります。
+
+## 設定手順
+
+### 1. Stripe Dashboardでの設定
+
+1. [Stripe Dashboard](https://dashboard.stripe.com/)にログイン
+2. 左メニューから「開発者」→「Webhook」を選択
+3. 「エンドポイントを追加」をクリック
+
+### 2. エンドポイントURLの設定
+
+以下の情報を入力：
+
+- **エンドポイントURL**: 
+  - 本番環境: `https://your-domain.com/api/stripe-webhook`
+  - 開発環境: `https://your-ngrok-url.ngrok.io/api/stripe-webhook` （ngrok使用時）
+
+### 3. リッスンするイベントの選択
+
+以下のイベントを選択：
+
+- `checkout.session.completed` - 決済完了時
+- `checkout.session.expired` - セッション期限切れ時
+- `payment_intent.payment_failed` - 決済失敗時
+
+### 4. Webhook署名シークレットの取得
+
+1. エンドポイントを作成後、「署名シークレット」セクションを確認
+2. 「表示」をクリックして署名シークレットを取得
+3. 環境変数に設定：
+
+```bash
+STRIPE_WEBHOOK_SECRET=whsec_xxxxxxxxxxxxxxxxxx
+```
+
+## ローカル開発環境での設定
+
+### Stripe CLIを使用する方法
+
+1. Stripe CLIをインストール：
+```bash
+# macOS
+brew install stripe/stripe-cli/stripe
+
+# Windows (Scoop)
+scoop install stripe
+
+# その他
+# https://stripe.com/docs/stripe-cli#install
+```
+
+2. ログイン：
+```bash
+stripe login
+```
+
+3. Webhookをローカルに転送：
+```bash
+stripe listen --forward-to localhost:3000/api/stripe-webhook
+```
+
+4. 表示される署名シークレットを環境変数に設定：
+```bash
+STRIPE_WEBHOOK_SECRET=whsec_test_xxxxxxxxxx
+```
+
+### ngrokを使用する方法
+
+1. ngrokをインストール：
+```bash
+# macOS
+brew install ngrok
+
+# その他
+# https://ngrok.com/download
+```
+
+2. ローカルサーバーを公開：
+```bash
+ngrok http 3000
+```
+
+3. 表示されるHTTPS URLをStripe Dashboardに設定
+4. Stripe Dashboardから署名シークレットを取得して環境変数に設定
+
+## 環境変数の設定
+
+`.env.local`ファイルに以下を追加：
+
+```env
+# Stripe Webhook Secret
+STRIPE_WEBHOOK_SECRET=whsec_xxxxxxxxxxxxxxxxxx
+```
+
+## テスト方法
+
+### 1. Stripe CLIでテストイベントを送信
+
+```bash
+# checkout.session.completedイベントをテスト
+stripe trigger checkout.session.completed
+```
+
+### 2. 実際の決済フローでテスト
+
+1. テストカード番号を使用：
+   - 成功: `4242 4242 4242 4242`
+   - 失敗: `4000 0000 0000 9995`
+
+2. 決済フローを実行して、以下を確認：
+   - 決済成功時: メールが送信される
+   - 決済キャンセル時: メールが送信されない
+   - 決済失敗時: メールが送信されない
+
+## トラブルシューティング
+
+### Webhook署名エラー
+
+エラー: `Invalid signature`
+
+対処法:
+- 環境変数 `STRIPE_WEBHOOK_SECRET` が正しく設定されているか確認
+- Stripe Dashboardの署名シークレットと一致しているか確認
+
+### イベントが受信されない
+
+対処法:
+- エンドポイントURLが正しいか確認
+- ファイアウォールやセキュリティ設定を確認
+- Stripe Dashboardでエンドポイントが有効になっているか確認
+
+### ローカル開発でWebhookが機能しない
+
+対処法:
+- Stripe CLIまたはngrokが正しく動作しているか確認
+- ローカルサーバーが起動しているか確認
+- ポート番号が正しいか確認
+
+## セキュリティ上の注意事項
+
+1. **署名検証は必須**: Webhookエンドポイントでは必ず署名を検証してください
+2. **HTTPS必須**: 本番環境では必ずHTTPSを使用してください
+3. **冪等性の実装**: 同じイベントが複数回送信される可能性があるため、冪等性を考慮した実装にしてください
+4. **タイムアウト**: Webhookは5秒以内にレスポンスを返す必要があります
+
+## 実装の詳細
+
+実装済みの機能:
+- `/app/api/stripe-webhook/route.ts`: Webhookエンドポイント
+- 決済完了時のメール送信
+- 決済失敗・キャンセル時の予約ステータス更新
+- クーポン使用履歴の記録
+
+変更点:
+- メール送信タイミングを決済開始時から決済完了時に変更
+- `/app/api/create-checkout-session/route.ts`からメール送信処理を削除

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -23,13 +23,14 @@ export default function AdminDashboard() {
 
   async function fetchData() {
     try {
-      // 予約情報を取得
+      // 予約情報を取得（クーポン情報も含む）
       const { data: bookingsData } = await supabase
         .from('bookings')
         .select(`
           *,
           workshop:workshops(*),
-          customer:customers(*)
+          customer:customers(*),
+          coupon:coupons(*)
         `)
         .order('created_at', { ascending: false })
 
@@ -260,7 +261,10 @@ export default function AdminDashboard() {
               <thead className="bg-gray-50">
                 <tr>
                   <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    予約日時
+                    作成日時
+                  </th>
+                  <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    ワークショップ開催日
                   </th>
                   <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     ワークショップ
@@ -272,7 +276,7 @@ export default function AdminDashboard() {
                     人数
                   </th>
                   <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    金額
+                    金額・クーポン
                   </th>
                   <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     ステータス
@@ -286,17 +290,47 @@ export default function AdminDashboard() {
                 {bookings.map((booking) => (
                   <tr key={booking.id} className="hover:bg-gray-50 transition-colors">
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900 font-medium">
-                        {new Date(booking.booking_date).toLocaleDateString('ja-JP', {
+                      <div className="text-sm text-gray-900">
+                        {new Date(booking.created_at).toLocaleDateString('ja-JP', {
                           year: 'numeric',
-                          month: 'long',
-                          day: 'numeric'
+                          month: '2-digit',
+                          day: '2-digit'
                         })}
                       </div>
-                      <div className="text-sm text-gray-500">
+                      <div className="text-xs text-gray-500">
                         <Clock className="w-3 h-3 inline mr-1" />
-                        {booking.booking_time}
+                        {new Date(booking.created_at).toLocaleTimeString('ja-JP', {
+                          hour: '2-digit',
+                          minute: '2-digit'
+                        })}
                       </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      {booking.workshop?.event_date ? (
+                        <div>
+                          <div className="text-sm text-gray-900 font-medium">
+                            {new Date(booking.workshop.event_date).toLocaleDateString('ja-JP', {
+                              year: 'numeric',
+                              month: '2-digit',
+                              day: '2-digit'
+                            })}
+                          </div>
+                          {booking.workshop?.event_time && (
+                            <div className="text-xs text-gray-500">
+                              <Clock className="w-3 h-3 inline mr-1" />
+                              {booking.workshop.event_time.slice(0, 5)}
+                            </div>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="text-sm text-gray-900 font-medium">
+                          {new Date(booking.booking_date).toLocaleDateString('ja-JP', {
+                            year: 'numeric',
+                            month: '2-digit',
+                            day: '2-digit'
+                          })}
+                        </div>
+                      )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm font-medium text-gray-900">
@@ -328,6 +362,19 @@ export default function AdminDashboard() {
                       <div className="text-sm font-semibold text-gray-900">
                         ¥{booking.total_amount.toLocaleString()}
                       </div>
+                      {booking.coupon && (
+                        <div className="mt-1">
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                            <Tag className="w-3 h-3 mr-1" />
+                            {booking.coupon.code}
+                          </span>
+                          {booking.discount_amount > 0 && (
+                            <div className="text-xs text-green-600 mt-0.5">
+                              -¥{booking.discount_amount.toLocaleString()}
+                            </div>
+                          )}
+                        </div>
+                      )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${

--- a/app/api/create-checkout-session/route.ts
+++ b/app/api/create-checkout-session/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { stripe } from '@/lib/stripe'
 import { supabaseAdmin } from '@/lib/supabase-admin'
-import { sendEmail, generateBookingConfirmationEmail } from '@/app/lib/email'
 
 export async function POST(request: NextRequest) {
   try {
@@ -61,36 +60,8 @@ export async function POST(request: NextRequest) {
       })
       .eq('id', booking_id)
 
-    // 顧客情報を取得
-    const { data: booking } = await supabaseAdmin
-      .from('bookings')
-      .select('*, customers(*)')
-      .eq('id', booking_id)
-      .single()
-
-    if (booking && booking.customers) {
-      // 予約確認メールを送信
-      const emailContent = generateBookingConfirmationEmail(
-        workshop.title,
-        workshop.event_date ? new Date(workshop.event_date).toLocaleDateString('ja-JP', {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-          weekday: 'long'
-        }) : '未定',
-        workshop.event_time ? workshop.event_time.slice(0, 5) : '未定',
-        workshop.location || '未定',
-        booking.customers.name,
-        booking.customers.email
-      )
-
-      await sendEmail({
-        to: booking.customers.email,
-        cc: ['yuho.ito@walker.co.jp', 'y-sato@sunu25.com'],
-        subject: emailContent.subject,
-        html: emailContent.html
-      })
-    }
+    // メール送信はWebhookで決済完了後に行うため、ここでは送信しない
+    // 決済完了の確認はStripe Webhookで行います
 
     return NextResponse.json({ sessionId: session.id })
   } catch (error) {

--- a/app/api/create-checkout-session/route.ts
+++ b/app/api/create-checkout-session/route.ts
@@ -7,6 +7,11 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const { workshop_id, booking_id, customer_email, amount, participants, coupon_id, discount_amount } = body
 
+    // リクエストから現在のホストを取得
+    const host = request.headers.get('host')
+    const protocol = request.headers.get('x-forwarded-proto') || 'http'
+    const baseUrl = `${protocol}://${host}`
+
     if (!supabaseAdmin) {
       throw new Error('Supabase admin client not available')
     }
@@ -40,8 +45,8 @@ export async function POST(request: NextRequest) {
       ],
       mode: 'payment',
       customer_email: customer_email,
-      success_url: `${process.env.NEXT_PUBLIC_APP_URL}/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/workshops/${workshop_id}`,
+      success_url: `${baseUrl}/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${baseUrl}/workshops/${workshop_id}`,
       metadata: {
         booking_id: booking_id,
         workshop_id: workshop_id,

--- a/app/api/stripe-webhook/route.ts
+++ b/app/api/stripe-webhook/route.ts
@@ -1,0 +1,206 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+import Stripe from 'stripe'
+import { supabaseAdmin } from '@/lib/supabase-admin'
+import { sendEmail, generateBookingConfirmationEmail } from '@/app/lib/email'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2025-07-30.basil',
+})
+
+export async function POST(request: NextRequest) {
+  const body = await request.text()
+  const signature = (await headers()).get('stripe-signature')
+
+  if (!signature) {
+    return NextResponse.json(
+      { error: 'No signature' },
+      { status: 400 }
+    )
+  }
+
+  let event: Stripe.Event
+
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET!
+    )
+  } catch (err) {
+    console.error('Webhook signature verification failed:', err)
+    return NextResponse.json(
+      { error: 'Invalid signature' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session
+        
+        // 支払いが完了していることを確認
+        if (session.payment_status !== 'paid') {
+          console.log('Payment not completed for session:', session.id)
+          return NextResponse.json({ received: true })
+        }
+
+        // メタデータから予約IDとクーポン情報を取得
+        const bookingId = session.metadata?.booking_id
+        const couponId = session.metadata?.coupon_id
+        const discountAmount = parseInt(session.metadata?.discount_amount || '0')
+
+        if (!bookingId) {
+          console.error('Booking ID not found in session metadata')
+          return NextResponse.json({ received: true })
+        }
+
+        if (!supabaseAdmin) {
+          throw new Error('Supabase admin client not available')
+        }
+
+        // 予約情報を更新
+        const { data: booking, error: bookingError } = await supabaseAdmin
+          .from('bookings')
+          .update({
+            status: 'confirmed',
+            payment_status: 'paid',
+            stripe_session_id: session.id,
+            stripe_payment_intent_id: session.payment_intent as string
+          })
+          .eq('id', bookingId)
+          .select(`
+            *,
+            workshops(*),
+            customers(*)
+          `)
+          .single()
+
+        if (bookingError) {
+          console.error('Error updating booking:', bookingError)
+          throw bookingError
+        }
+
+        // クーポンが使用された場合、使用履歴を記録
+        if (couponId && discountAmount > 0 && booking) {
+          // クーポンの現在の使用回数を取得
+          const { data: couponData } = await supabaseAdmin
+            .from('coupons')
+            .select('usage_count')
+            .eq('id', couponId)
+            .single()
+          
+          if (couponData) {
+            // クーポンの使用回数を増やす
+            await supabaseAdmin
+              .from('coupons')
+              .update({
+                usage_count: couponData.usage_count + 1
+              })
+              .eq('id', couponId)
+          }
+
+          // クーポン使用履歴を作成
+          await supabaseAdmin
+            .from('coupon_usage')
+            .insert({
+              coupon_id: couponId,
+              booking_id: bookingId,
+              customer_id: booking.customer_id,
+              discount_amount: discountAmount
+            })
+        }
+
+        // 顧客のStripe IDを更新
+        if (session.customer && session.customer_email) {
+          await supabaseAdmin
+            .from('customers')
+            .update({
+              stripe_customer_id: session.customer as string
+            })
+            .eq('email', session.customer_email)
+        }
+
+        // 予約確認メールを送信（決済完了後）
+        if (booking && booking.workshops && booking.customers) {
+          const workshop = booking.workshops
+          const customer = booking.customers
+          
+          const emailContent = generateBookingConfirmationEmail(
+            workshop.title,
+            workshop.event_date ? new Date(workshop.event_date).toLocaleDateString('ja-JP', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+              weekday: 'long'
+            }) : '未定',
+            workshop.event_time ? workshop.event_time.slice(0, 5) : '未定',
+            workshop.location || '未定',
+            customer.name,
+            customer.email
+          )
+
+          await sendEmail({
+            to: customer.email,
+            cc: ['yuho.ito@walker.co.jp', 'y-sato@sunu25.com'],
+            subject: emailContent.subject,
+            html: emailContent.html
+          })
+
+          console.log(`Confirmation email sent to ${customer.email} for booking ${bookingId}`)
+        }
+
+        break
+      }
+
+      case 'checkout.session.expired': {
+        const session = event.data.object as Stripe.Checkout.Session
+        const bookingId = session.metadata?.booking_id
+
+        if (bookingId && supabaseAdmin) {
+          // セッションが期限切れになった場合、予約をキャンセル
+          await supabaseAdmin
+            .from('bookings')
+            .update({
+              status: 'cancelled',
+              payment_status: 'failed'
+            })
+            .eq('id', bookingId)
+
+          console.log(`Booking ${bookingId} cancelled due to expired session`)
+        }
+        break
+      }
+
+      case 'payment_intent.payment_failed': {
+        const paymentIntent = event.data.object as Stripe.PaymentIntent
+        
+        // payment_intentのメタデータから予約IDを取得
+        if (paymentIntent.metadata?.booking_id && supabaseAdmin) {
+          await supabaseAdmin
+            .from('bookings')
+            .update({
+              status: 'cancelled',
+              payment_status: 'failed'
+            })
+            .eq('id', paymentIntent.metadata.booking_id)
+
+          console.log(`Booking ${paymentIntent.metadata.booking_id} cancelled due to payment failure`)
+        }
+        break
+      }
+
+      default:
+        console.log(`Unhandled event type: ${event.type}`)
+    }
+
+    return NextResponse.json({ received: true })
+  } catch (error) {
+    console.error('Error processing webhook:', error)
+    return NextResponse.json(
+      { error: 'Webhook processing failed' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
  - Stripe Webhookエンドポイントを実装し、決済が実際に完了した場合のみメールを送信するよう修正
  - 決済キャンセル・失敗時の予約ステータス更新処理を追加
  - Webhook設定手順書を作成

  ## 問題の背景
  決済が完了していなくてもメールが送信される問題がありました。これは、Stripeのチェックアウトセッション作成時（決
  済開始時）にメールを送信していたことが原因でした。

  ## 変更内容

  ### 1. Stripe Webhookエンドポイントの実装
  - \`/app/api/stripe-webhook/route.ts\`を新規作成
  - 以下のイベントを処理:
    - \`checkout.session.completed\`: 決済完了時にメール送信と予約確認
    - \`checkout.session.expired\`: セッション期限切れ時に予約キャンセル
    - \`payment_intent.payment_failed\`: 決済失敗時に予約キャンセル

  ### 2. 既存のメール送信処理を削除
  - \`/app/api/create-checkout-session/route.ts\`から早期メール送信処理を削除
  - メール送信はWebhookで決済完了確認後に行うよう変更

  ### 3. 設定ドキュメントの追加
  - \`STRIPE_WEBHOOK_SETUP.md\`: Webhook設定の詳細な手順書
  - \`.env.example\`: \`STRIPE_WEBHOOK_SECRET\`環境変数を追加

  ## Test plan
  - [ ] Stripe CLIでローカル環境でWebhookをテスト
  - [ ] テストカード（4242 4242 4242 4242）で決済成功時のメール送信を確認
  - [ ] 決済をキャンセルした場合にメールが送信されないことを確認
  - [ ] 本番環境でStripe DashboardからWebhookエンドポイントを設定
  - [ ] 環境変数\`STRIPE_WEBHOOK_SECRET\`を設定