### PR TITLE
feat: ワークショップカテゴリ機能を追加

### DIFF
--- a/app/admin/categories/[id]/edit/page.tsx
+++ b/app/admin/categories/[id]/edit/page.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { WorkshopCategory } from '@/types'
+import LoadingOverlay from '@/components/LoadingOverlay'
+import { ArrowLeft, Save, Type, Link, FileText, Image as ImageIcon, Hash, Trash2 } from 'lucide-react'
+
+export default function EditCategoryPage() {
+  const params = useParams()
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [category, setCategory] = useState<WorkshopCategory | null>(null)
+  const [formData, setFormData] = useState({
+    name: '',
+    slug: '',
+    description: '',
+    image_url: '',
+    sort_order: '0'
+  })
+  const [saving, setSaving] = useState(false)
+  const [navigating, setNavigating] = useState(false)
+
+  useEffect(() => {
+    async function fetchCategory() {
+      const { data, error } = await supabase
+        .from('workshop_categories')
+        .select('*')
+        .eq('id', params.id)
+        .single()
+
+      if (error) {
+        console.error('Error fetching category:', error)
+      } else {
+        const cat = data as WorkshopCategory
+        setCategory(cat)
+        setFormData({
+          name: cat.name,
+          slug: cat.slug,
+          description: cat.description || '',
+          image_url: cat.image_url || '',
+          sort_order: cat.sort_order.toString()
+        })
+      }
+      setLoading(false)
+    }
+
+    fetchCategory()
+  }, [params.id])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!formData.slug.match(/^[a-z0-9-]+$/)) {
+      alert('スラッグは半角英数字とハイフンのみ使用できます')
+      return
+    }
+
+    setSaving(true)
+
+    try {
+      const { error } = await supabase
+        .from('workshop_categories')
+        .update({
+          name: formData.name,
+          slug: formData.slug,
+          description: formData.description || null,
+          image_url: formData.image_url || null,
+          sort_order: parseInt(formData.sort_order) || 0,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', params.id)
+
+      if (error) throw error
+
+      alert('カテゴリを更新しました')
+      setNavigating(true)
+      router.push('/admin?tab=categories')
+    } catch (error) {
+      console.error('Error updating category:', error)
+      alert('カテゴリの更新に失敗しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm('本当に削除しますか？カテゴリを削除しても、紐付いているワークショップは削除されません。')) {
+      return
+    }
+
+    try {
+      const { error } = await supabase
+        .from('workshop_categories')
+        .delete()
+        .eq('id', params.id)
+
+      if (error) throw error
+
+      alert('カテゴリを削除しました')
+      setNavigating(true)
+      router.push('/admin?tab=categories')
+    } catch (error) {
+      console.error('Error deleting category:', error)
+      alert('カテゴリの削除に失敗しました')
+    }
+  }
+
+  const handleBack = () => {
+    setNavigating(true)
+    router.push('/admin?tab=categories')
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+      </div>
+    )
+  }
+
+  if (!category) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-red-600 mb-4">カテゴリが見つかりません</p>
+          <button
+            onClick={() => router.push('/admin?tab=categories')}
+            className="text-purple-600 hover:underline"
+          >
+            管理画面へ戻る
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {navigating && <LoadingOverlay message="管理画面へ戻っています..." />}
+      {saving && <LoadingOverlay message="カテゴリを更新しています..." />}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <button
+          onClick={handleBack}
+          className="flex items-center text-gray-600 hover:text-purple-600 font-medium transition-colors mb-6"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          管理画面に戻る
+        </button>
+
+        <div className="bg-white shadow-xl rounded-2xl overflow-hidden">
+          <div className="bg-gradient-to-r from-purple-600 to-pink-600 p-6">
+            <h2 className="text-2xl font-bold text-white">カテゴリ編集</h2>
+            <p className="text-white/80 mt-1">{category.name}</p>
+          </div>
+
+          <div className="p-8">
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="bg-purple-50 rounded-xl p-6 space-y-4">
+                <h3 className="text-lg font-semibold text-gray-900 flex items-center mb-4">
+                  <Type className="w-5 h-5 mr-2 text-purple-600" />
+                  基本情報
+                </h3>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    カテゴリ名 *
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all text-gray-900"
+                    value={formData.name}
+                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    <Link className="w-4 h-4 inline mr-1" />
+                    スラッグ *
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all text-gray-900"
+                    value={formData.slug}
+                    onChange={(e) => setFormData({ ...formData, slug: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') })}
+                  />
+                  <p className="text-xs text-gray-500 mt-1">URLに使用されます。半角英数字とハイフンのみ</p>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <h3 className="text-lg font-semibold text-gray-900 flex items-center">
+                  <FileText className="w-5 h-5 mr-2 text-purple-600" />
+                  説明
+                </h3>
+                <textarea
+                  rows={5}
+                  className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all resize-none text-gray-900"
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder="カテゴリのピラーページに表示される説明文"
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    <ImageIcon className="w-4 h-4 inline mr-1" />
+                    画像URL
+                  </label>
+                  <input
+                    type="url"
+                    className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all text-gray-900"
+                    value={formData.image_url}
+                    onChange={(e) => setFormData({ ...formData, image_url: e.target.value })}
+                    placeholder="https://example.com/image.jpg"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    <Hash className="w-4 h-4 inline mr-1" />
+                    並び順
+                  </label>
+                  <input
+                    type="number"
+                    min="0"
+                    className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all text-gray-900"
+                    value={formData.sort_order}
+                    onChange={(e) => setFormData({ ...formData, sort_order: e.target.value })}
+                  />
+                  <p className="text-xs text-gray-500 mt-1">小さい数字が先に表示されます</p>
+                </div>
+              </div>
+
+              <div className="flex justify-between pt-6 border-t border-gray-200">
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="px-6 py-3 bg-red-600 text-white rounded-xl font-medium hover:bg-red-700 transition-all flex items-center"
+                >
+                  <Trash2 className="w-4 h-4 mr-2" />
+                  削除
+                </button>
+
+                <div className="flex space-x-4">
+                  <button
+                    type="button"
+                    onClick={handleBack}
+                    className="px-6 py-3 border border-gray-300 rounded-xl text-gray-700 hover:bg-gray-50 font-medium transition-all"
+                  >
+                    キャンセル
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={saving}
+                    className="px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-xl font-medium hover:shadow-lg transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+                  >
+                    <Save className="w-4 h-4 mr-2" />
+                    {saving ? '更新中...' : 'カテゴリを更新'}
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/admin/categories/new/page.tsx
+++ b/app/admin/categories/new/page.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import LoadingOverlay from '@/components/LoadingOverlay'
+import { ArrowLeft, Save, Type, Link, FileText, Image as ImageIcon, Hash } from 'lucide-react'
+
+export default function NewCategoryPage() {
+  const router = useRouter()
+  const [formData, setFormData] = useState({
+    name: '',
+    slug: '',
+    description: '',
+    image_url: '',
+    sort_order: '0'
+  })
+  const [saving, setSaving] = useState(false)
+  const [navigating, setNavigating] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!formData.slug.match(/^[a-z0-9-]+$/)) {
+      alert('スラッグは半角英数字とハイフンのみ使用できます')
+      return
+    }
+
+    setSaving(true)
+
+    try {
+      const { error } = await supabase
+        .from('workshop_categories')
+        .insert({
+          name: formData.name,
+          slug: formData.slug,
+          description: formData.description || null,
+          image_url: formData.image_url || null,
+          sort_order: parseInt(formData.sort_order) || 0
+        })
+
+      if (error) throw error
+
+      alert('カテゴリを作成しました')
+      setNavigating(true)
+      router.push('/admin?tab=categories')
+    } catch (error) {
+      console.error('Error creating category:', error)
+      alert('カテゴリの作成に失敗しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleBack = () => {
+    setNavigating(true)
+    router.push('/admin?tab=categories')
+  }
+
+  return (
+    <>
+      {navigating && <LoadingOverlay message="管理画面へ戻っています..." />}
+      {saving && <LoadingOverlay message="カテゴリを作成しています..." />}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <button
+          onClick={handleBack}
+          className="flex items-center text-gray-600 hover:text-purple-600 font-medium transition-colors mb-6"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          管理画面に戻る
+        </button>
+
+        <div className="bg-white shadow-xl rounded-2xl overflow-hidden">
+          <div className="bg-gradient-to-r from-purple-600 to-pink-600 p-6">
+            <h2 className="text-2xl font-bold text-white">新規カテゴリ作成</h2>
+            <p className="text-white/80 mt-1">ワークショップカテゴリの情報を入力してください</p>
+          </div>
+
+          <div className="p-8">
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="bg-purple-50 rounded-xl p-6 space-y-4">
+                <h3 className="text-lg font-semibold text-gray-900 flex items-center mb-4">
+                  <Type className="w-5 h-5 mr-2 text-purple-600" />
+                  基本情報
+                </h3>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    カテゴリ名 *
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all text-gray-900"
+                    value={formData.name}
+                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                    placeholder="3Dプリンター入門"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    <Link className="w-4 h-4 inline mr-1" />
+                    スラッグ *
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all text-gray-900"
+                    value={formData.slug}
+                    onChange={(e) => setFormData({ ...formData, slug: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') })}
+                    placeholder="3d-printer-intro"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">URLに使用されます。半角英数字とハイフンのみ</p>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <h3 className="text-lg font-semibold text-gray-900 flex items-center">
+                  <FileText className="w-5 h-5 mr-2 text-purple-600" />
+                  説明
+                </h3>
+                <textarea
+                  rows={5}
+                  className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all resize-none text-gray-900"
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder="カテゴリのピラーページに表示される説明文"
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    <ImageIcon className="w-4 h-4 inline mr-1" />
+                    画像URL
+                  </label>
+                  <input
+                    type="url"
+                    className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all text-gray-900"
+                    value={formData.image_url}
+                    onChange={(e) => setFormData({ ...formData, image_url: e.target.value })}
+                    placeholder="https://example.com/image.jpg"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    <Hash className="w-4 h-4 inline mr-1" />
+                    並び順
+                  </label>
+                  <input
+                    type="number"
+                    min="0"
+                    className="w-full px-4 py-3 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all text-gray-900"
+                    value={formData.sort_order}
+                    onChange={(e) => setFormData({ ...formData, sort_order: e.target.value })}
+                    placeholder="0"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">小さい数字が先に表示されます</p>
+                </div>
+              </div>
+
+              <div className="flex justify-end space-x-4 pt-6 border-t border-gray-200">
+                <button
+                  type="button"
+                  onClick={handleBack}
+                  className="px-6 py-3 border border-gray-300 rounded-xl text-gray-700 hover:bg-gray-50 font-medium transition-all"
+                >
+                  <ArrowLeft className="w-4 h-4 inline mr-2" />
+                  キャンセル
+                </button>
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-xl font-medium hover:shadow-lg transition-all duration-300 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+                >
+                  <Save className="w-4 h-4 mr-2" />
+                  {saving ? '作成中...' : 'カテゴリを作成'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -93,6 +93,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     }))
 
+    // カテゴリピラーページを動的に追加
+    const { data: categories } = await supabase
+      .from('workshop_categories')
+      .select('slug, updated_at')
+      .order('sort_order', { ascending: true })
+
+    const categoryPages: MetadataRoute.Sitemap = (categories || []).map((category) => ({
+      url: `${baseUrl}/workshops/category/${category.slug}`,
+      lastModified: category.updated_at ? new Date(category.updated_at) : new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    }))
+
     // ブログ記事を動的に追加
     const { data: blogPosts } = await supabase
       .from('blog_posts')
@@ -111,7 +124,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
     }))
 
-    return [...staticPages, ...workshopPages, ...blogPages]
+    return [...staticPages, ...workshopPages, ...categoryPages, ...blogPages]
   } catch (error) {
     console.error('Error generating sitemap:', error)
     return staticPages

--- a/app/workshops/category/[slug]/page.tsx
+++ b/app/workshops/category/[slug]/page.tsx
@@ -1,0 +1,326 @@
+import { Metadata } from 'next'
+import { createClient } from '@supabase/supabase-js'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import Image from 'next/image'
+import Header from '@/components/Header'
+import { Calendar, Clock, ArrowRight } from 'lucide-react'
+import { optimizeImageUrl } from '@/lib/image-optimization'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+interface Props {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+
+  const { data: category } = await supabase
+    .from('workshop_categories')
+    .select('*')
+    .eq('slug', slug)
+    .single()
+
+  if (!category) {
+    return { title: 'カテゴリが見つかりません | 3DLab' }
+  }
+
+  return {
+    title: `${category.name} ワークショップ | 3DLab 東京`,
+    description: category.description || `${category.name}のワークショップ一覧。東京・湯島の3Dプリンタ教室3DLabで開催。初心者歓迎。`,
+    openGraph: {
+      title: `${category.name} ワークショップ | 3DLab 東京`,
+      description: category.description || `${category.name}のワークショップ一覧`,
+      images: category.image_url ? [{ url: category.image_url }] : undefined,
+    },
+  }
+}
+
+export default async function CategoryPillarPage({ params }: Props) {
+  const { slug } = await params
+
+  const { data: category } = await supabase
+    .from('workshop_categories')
+    .select('*')
+    .eq('slug', slug)
+    .single()
+
+  if (!category) {
+    notFound()
+  }
+
+  const { data: workshops } = await supabase
+    .from('workshops')
+    .select('*')
+    .eq('category_id', category.id)
+    .order('event_date', { ascending: true })
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const upcomingWorkshops = (workshops || []).filter(w => {
+    if (!w.event_date) return true
+    return new Date(w.event_date) >= today
+  })
+
+  const pastWorkshops = (workshops || []).filter(w => {
+    if (!w.event_date) return false
+    return new Date(w.event_date) < today
+  }).reverse()
+
+  // 構造化データ
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'ホーム', item: 'https://3dlab.jp' },
+      { '@type': 'ListItem', position: 2, name: 'ワークショップ', item: 'https://3dlab.jp/workshops' },
+      { '@type': 'ListItem', position: 3, name: category.name, item: `https://3dlab.jp/workshops/category/${slug}` },
+    ],
+  }
+
+  const itemListData = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `${category.name} ワークショップ`,
+    itemListElement: upcomingWorkshops.map((w, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: `https://3dlab.jp/workshops/${w.id}`,
+      name: w.title,
+    })),
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-purple-50 via-white to-pink-50">
+      <Header />
+
+      {/* Structured Data */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListData) }}
+      />
+
+      {/* Breadcrumb */}
+      <div className="pt-20 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
+          <nav className="flex items-center space-x-2 text-sm text-gray-500 mb-6">
+            <Link href="/" className="hover:text-purple-600 transition-colors">ホーム</Link>
+            <span>/</span>
+            <Link href="/workshops" className="hover:text-purple-600 transition-colors">ワークショップ</Link>
+            <span>/</span>
+            <span className="text-gray-900 font-medium">{category.name}</span>
+          </nav>
+        </div>
+      </div>
+
+      {/* Category Header */}
+      <section className="px-4 sm:px-6 lg:px-8 pb-12">
+        <div className="max-w-7xl mx-auto">
+          <div className="bg-white rounded-2xl shadow-lg overflow-hidden">
+            <div className="grid md:grid-cols-2 gap-0">
+              {category.image_url ? (
+                <div className="relative aspect-video md:aspect-auto">
+                  <Image
+                    src={optimizeImageUrl(category.image_url)}
+                    alt={`${category.name} ワークショップ`}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 100vw, 50vw"
+                    priority
+                  />
+                </div>
+              ) : (
+                <div className="aspect-video md:aspect-auto bg-gradient-to-br from-purple-100 to-pink-100 flex items-center justify-center min-h-[200px]">
+                  <div className="w-24 h-24 bg-white/50 rounded-2xl flex items-center justify-center">
+                    <span className="text-4xl font-bold text-purple-600">3D</span>
+                  </div>
+                </div>
+              )}
+              <div className="p-8 md:p-12 flex flex-col justify-center">
+                <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+                  {category.name}
+                </h1>
+                {category.description && (
+                  <p className="text-lg text-gray-600 leading-relaxed">
+                    {category.description}
+                  </p>
+                )}
+                <div className="mt-6 flex items-center space-x-4 text-sm text-gray-500">
+                  <span className="inline-flex items-center px-3 py-1 bg-purple-100 text-purple-700 rounded-full">
+                    開催予定 {upcomingWorkshops.length}件
+                  </span>
+                  {pastWorkshops.length > 0 && (
+                    <span className="inline-flex items-center px-3 py-1 bg-gray-100 text-gray-600 rounded-full">
+                      過去の開催 {pastWorkshops.length}件
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Upcoming Workshops */}
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
+        {upcomingWorkshops.length > 0 && (
+          <section className="mb-16">
+            <div className="flex items-center mb-8">
+              <h2 className="text-2xl font-bold text-gray-900">開催予定</h2>
+              <span className="ml-3 w-2 h-2 bg-green-400 rounded-full animate-pulse"></span>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {upcomingWorkshops.map((workshop) => (
+                <Link
+                  key={workshop.id}
+                  href={`/workshops/${workshop.id}`}
+                  className="group bg-white rounded-2xl shadow-sm hover:shadow-xl transition-all duration-300 overflow-hidden hover:-translate-y-1"
+                >
+                  {workshop.image_url ? (
+                    <div className="relative w-full aspect-video overflow-hidden bg-gray-100">
+                      <Image
+                        src={optimizeImageUrl(workshop.image_url, 75)}
+                        alt={workshop.title}
+                        fill
+                        className="object-contain group-hover:scale-105 transition-transform duration-300"
+                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        loading="lazy"
+                      />
+                    </div>
+                  ) : (
+                    <div className="w-full aspect-video bg-gradient-to-br from-purple-100 to-pink-100 flex items-center justify-center">
+                      <span className="text-3xl font-bold text-purple-600">3D</span>
+                    </div>
+                  )}
+                  <div className="p-6">
+                    <h3 className="text-lg font-bold text-gray-900 mb-2 line-clamp-1">{workshop.title}</h3>
+                    <p className="text-gray-600 text-sm mb-4 line-clamp-2">{workshop.description}</p>
+                    {workshop.event_date && (
+                      <div className="flex items-center text-sm text-gray-600 mb-2">
+                        <Calendar className="w-4 h-4 mr-2 text-purple-500" />
+                        {new Date(workshop.event_date).toLocaleDateString('ja-JP', {
+                          year: 'numeric', month: 'long', day: 'numeric', weekday: 'short'
+                        })}
+                      </div>
+                    )}
+                    {workshop.event_time && (
+                      <div className="flex items-center text-sm text-gray-600 mb-2">
+                        <Clock className="w-4 h-4 mr-2 text-purple-500" />
+                        {workshop.event_time.slice(0, 5)} 〜（{workshop.duration}分）
+                      </div>
+                    )}
+                    <div className="flex items-center justify-between pt-4 border-t border-gray-100">
+                      <p className="text-2xl font-bold text-gray-900">¥{workshop.price.toLocaleString()}</p>
+                      <span className="px-4 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-full text-sm font-medium group-hover:shadow-lg transition-all">
+                        詳細を見る
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {upcomingWorkshops.length === 0 && (
+          <section className="mb-16">
+            <div className="text-center py-16 bg-white rounded-2xl shadow-sm">
+              <Calendar className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+              <p className="text-gray-500 text-lg mb-2">現在、開催予定のワークショップはありません</p>
+              <p className="text-gray-400 text-sm">新しい日程が決まり次第、こちらに掲載されます</p>
+            </div>
+          </section>
+        )}
+
+        {/* Past Workshops */}
+        {pastWorkshops.length > 0 && (
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900 mb-8">過去の開催</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {pastWorkshops.map((workshop) => (
+                <Link
+                  key={workshop.id}
+                  href={`/workshops/${workshop.id}`}
+                  className="group bg-white rounded-2xl shadow-sm hover:shadow-lg transition-all duration-300 overflow-hidden opacity-75 hover:opacity-100"
+                >
+                  <div className="relative">
+                    {workshop.image_url ? (
+                      <div className="relative w-full aspect-video overflow-hidden bg-gray-100">
+                        <Image
+                          src={optimizeImageUrl(workshop.image_url, 75)}
+                          alt={workshop.title}
+                          fill
+                          className="object-contain"
+                          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                          loading="lazy"
+                        />
+                      </div>
+                    ) : (
+                      <div className="w-full aspect-video bg-gradient-to-br from-gray-100 to-gray-200 flex items-center justify-center">
+                        <span className="text-3xl font-bold text-gray-400">3D</span>
+                      </div>
+                    )}
+                    <div className="absolute top-4 right-4 px-3 py-1 bg-gray-700 text-white text-xs font-medium rounded-full">
+                      終了
+                    </div>
+                  </div>
+                  <div className="p-6">
+                    <h3 className="text-lg font-bold text-gray-900 mb-2 line-clamp-1">{workshop.title}</h3>
+                    {workshop.event_date && (
+                      <div className="flex items-center text-sm text-gray-500 mb-2">
+                        <Calendar className="w-4 h-4 mr-2" />
+                        {new Date(workshop.event_date).toLocaleDateString('ja-JP', {
+                          year: 'numeric', month: 'long', day: 'numeric'
+                        })}
+                      </div>
+                    )}
+                    <div className="flex items-center text-sm text-purple-600 font-medium">
+                      開催レポートを見る
+                      <ArrowRight className="w-4 h-4 ml-1" />
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+
+      {/* SEO Content */}
+      <section className="bg-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto prose prose-lg">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">
+            {category.name} ワークショップについて
+          </h2>
+          <div className="text-gray-700 leading-relaxed space-y-4">
+            <p>
+              3DLab（スリーディーラボ）では、東京都文京区湯島にて「{category.name}」ワークショップを定期開催しています。
+              東京メトロ千代田線 湯島駅から徒歩1分、JR御徒町駅から徒歩8分とアクセス便利な立地です。
+            </p>
+            <p>
+              初心者の方も安心してご参加いただける少人数制で、一人ひとりに丁寧に指導いたします。
+              最新の3Dプリンター機材を使用した実践的な体験ができます。
+            </p>
+          </div>
+          <div className="mt-8 text-center">
+            <Link
+              href="/workshops"
+              className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-full font-medium hover:shadow-lg transition-all no-underline"
+            >
+              全てのワークショップを見る
+              <ArrowRight className="w-4 h-4 ml-2" />
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,8 +4,12 @@ import type { NextRequest } from 'next/server'
 export function middleware(request: NextRequest) {
   const host = request.headers.get('host') || ''
 
-  // Netlifyサブドメインからのアクセスをリダイレクト
+  // Netlifyプレビューデプロイ（deploy-preview-*）はリダイレクトしない
+  // 本番用のNetlifyサブドメインのみ3dlab.jpへリダイレクト
   if (host.includes('netlify.app')) {
+    if (host.includes('deploy-preview-') || host.includes('--')) {
+      return NextResponse.next()
+    }
     const url = request.nextUrl.clone()
     url.protocol = 'https:'
     url.host = '3dlab.jp'

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,8 +9,11 @@
   NEXT_USE_NETLIFY_EDGE = "true"
   SECRETS_SCAN_ENABLED = "false"
 
+# 本番環境のみリダイレクトルール適用（プレビューデプロイには適用しない）
+[context.production]
+
 # Netlifyデフォルトドメインから3dlab.jpへリダイレクト
-[[redirects]]
+[[context.production.redirects]]
   from = "/*"
   to = "https://3dlab.jp/:splat"
   status = 301
@@ -18,7 +21,7 @@
   conditions = {Host = ["3dworkshop.netlify.app"]}
 
 # wwwから非wwwへリダイレクト
-[[redirects]]
+[[context.production.redirects]]
   from = "/*"
   to = "https://3dlab.jp/:splat"
   status = 301

--- a/supabase/migrations/20250217_add_workshop_categories.sql
+++ b/supabase/migrations/20250217_add_workshop_categories.sql
@@ -1,0 +1,33 @@
+-- Workshop Categories テーブル作成
+CREATE TABLE IF NOT EXISTS public.workshop_categories (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  slug VARCHAR(255) UNIQUE NOT NULL,
+  description TEXT,
+  image_url TEXT,
+  sort_order INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- workshops テーブルに category_id カラム追加
+ALTER TABLE public.workshops
+  ADD COLUMN IF NOT EXISTS category_id UUID REFERENCES public.workshop_categories(id) ON DELETE SET NULL;
+
+-- インデックス作成
+CREATE INDEX IF NOT EXISTS idx_workshops_category_id ON public.workshops(category_id);
+
+-- RLS ポリシー: 全員が閲覧可能
+ALTER TABLE public.workshop_categories ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "workshop_categories_select_all" ON public.workshop_categories
+  FOR SELECT USING (true);
+
+CREATE POLICY "workshop_categories_insert_all" ON public.workshop_categories
+  FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "workshop_categories_update_all" ON public.workshop_categories
+  FOR UPDATE USING (true);
+
+CREATE POLICY "workshop_categories_delete_all" ON public.workshop_categories
+  FOR DELETE USING (true);

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,14 @@
+export interface WorkshopCategory {
+  id: string
+  name: string
+  slug: string
+  description?: string | null
+  image_url?: string | null
+  sort_order: number
+  created_at: string
+  updated_at: string
+}
+
 export interface Workshop {
   id: string
   title: string
@@ -14,6 +25,8 @@ export interface Workshop {
   price: number
   is_pinned: boolean
   pin_order: number | null
+  category_id?: string | null
+  category?: WorkshopCategory | null
   created_at?: string
   updated_at?: string
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,3 +1,14 @@
+export interface WorkshopCategory {
+  id: string
+  name: string
+  slug: string
+  description?: string | null
+  image_url?: string | null
+  sort_order: number
+  created_at: string
+  updated_at: string
+}
+
 export interface Workshop {
   id: string
   title: string
@@ -16,6 +27,8 @@ export interface Workshop {
   pin_order?: number | null
   manual_participants?: number | null
   manual_participants_note?: string | null
+  category_id?: string | null
+  category?: WorkshopCategory | null
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
## Summary
- ワークショップカテゴリ機能を全面的に実装（DB・管理画面・公開ページ・SEO）
- カテゴリごとのピラーページでSEO強化（構造化データ・generateMetadata対応）
- 「日程追加」機能で同カテゴリWSの内容をコピーし、管理工数を大幅削減
- 過去WS表示対応（終了バッジ・予約フォーム非表示・関連WS誘導）
- category_idはNULL許容で既存WSへの後方互換性を維持

## Changes

### DB
- `workshop_categories`テーブル作成（name, slug, description, image_url, sort_order）
- `workshops.category_id`カラム追加（FK, ON DELETE SET NULL）
- RLSポリシー設定

### 管理画面
- カテゴリCRUD（`/admin/categories/new`, `/admin/categories/[id]/edit`）
- ダッシュボードに「カテゴリ管理」タブ追加（WS数表示・日程追加ボタン）
- WS作成・編集にカテゴリ選択ドロップダウン追加
- `from_category`パラメータで直近WSの内容を自動コピー

### 公開ページ
- カテゴリピラーページ（`/workshops/category/[slug]`）- サーバーコンポーネント
- WS一覧にカテゴリフィルタバー（ピル型ボタン）
- 過去WSセクション（終了バッジ・opacity低下）
- WS詳細で過去WS判定 → 予約フォーム非表示・関連WS表示

### SEO
- ピラーページにBreadcrumbList + ItemList構造化データ
- サイトマップに`/workshops/category/[slug]`追加（priority 0.8）
- カテゴリ名をパンくず・タグとして表示

## Test plan
- [ ] Supabase SQLエディタでマイグレーション実行
- [ ] 管理画面でカテゴリ作成 → 「日程追加」で新WS作成 → 内容がコピーされていること
- [ ] `/workshops`でカテゴリフィルタ + 過去WS表示確認
- [ ] `/workshops/category/[slug]`でピラーページ確認
- [ ] 過去WSの詳細で予約フォーム非表示確認
- [ ] カテゴリなしの既存WSが正常に動作すること
- [ ] `npx tsc --noEmit`でビルド確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)